### PR TITLE
bump max base, tests passed using 8.8.1

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -12,7 +12,7 @@ synopsis:            Wake up and perform an action at a certain time.
 description:         Please see the README at <https://github.com/DaveCTurner/alarmclock/blob/master/README.md>
 
 dependencies:
-- base >=4.8 && <4.13
+- base >=4.8 && <4.14
 - stm
 - async
 - time


### PR DESCRIPTION
why bother putting such a tight cap on the max base? just irritating when there's a minor ghc update